### PR TITLE
fix(purgecss): improve safelist

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,7 +5,7 @@ module.exports = {
       {
         content: ['./pages/**/*.{mdx,tsx}', './components/**/*.{mdx,tsx}'],
         defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
-        safelist: ['html', 'body', 'data-theme', /^data-reach-/, 'class']
+        safelist: ['html', 'body', 'data-theme', /^data-reach-/]
       }
     ],
     'postcss-flexbugs-fixes',

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,7 +4,8 @@ module.exports = {
       '@fullhuman/postcss-purgecss',
       {
         content: ['./pages/**/*.{mdx,tsx}', './components/**/*.{mdx,tsx}'],
-        safelist: ['html', 'data-theme', /^data-reach-skip-nav/]
+        defaultExtractor: (content) => content.match(/[\w-/:]+(?<!:)/g) || [],
+        safelist: ['html', 'body', 'data-theme', /^data-reach-/, 'class']
       }
     ],
     'postcss-flexbugs-fixes',


### PR DESCRIPTION
Infimaはこれまで`[class*="col--"]`と`.col--n`で重複した定義がなされていたが facebookincubator/infima#166 で`col--n`の方が削除された。その結果`[class*="col--"]`をうまく扱ってくれないPurgeCSSが定義を消してしまっていた。

PurgeCSSの`safelist`設定に`class`属性を追加して消されないようにしたい。`safelist`で`class`を指定してもあくまで`[`と`]`の間に挟まれたもの以外は関係ないと思われるので大きな影響はさしてないと思われる。