### PR TITLE
style: adjust class order for consistency in various components

### DIFF
--- a/apps/admin/app/(dashboard)/layout.tsx
+++ b/apps/admin/app/(dashboard)/layout.tsx
@@ -11,13 +11,13 @@ export default function DashboardLayout({ children }: Props) {
   return (
     <div>
       <nav className="sticky flex bg-slate-800 p-2 text-slate-50">
-        <Link className="inline-block p-2 text-xl font-semibold" href="/">
+        <Link className="inline-block p-2 font-semibold text-xl" href="/">
           Admin UI
         </Link>
         <div className="flex grow items-center justify-end">
           <Form action={signOut}>
             <Button
-              className="rounded-md bg-slate-500 px-2 py-1 text-slate-50 hover:bg-slate-700 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-800 focus-visible:outline-none active:bg-slate-600 active:shadow-inner disabled:pointer-events-none disabled:bg-slate-400"
+              className="rounded-md bg-slate-500 px-2 py-1 text-slate-50 hover:bg-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-800 active:bg-slate-600 active:shadow-inner disabled:pointer-events-none disabled:bg-slate-400"
               type="submit"
             >
               ログアウト

--- a/apps/admin/app/(dashboard)/terms/layout.tsx
+++ b/apps/admin/app/(dashboard)/terms/layout.tsx
@@ -12,7 +12,7 @@ export default function TermsLayout({
 }>) {
   return (
     <div className="mx-auto max-w-6xl space-y-8 px-8 py-4 md:px-4">
-      <h1 className="text-2xl font-semibold">用語集</h1>
+      <h1 className="font-semibold text-2xl">用語集</h1>
 
       <main>{children}</main>
     </div>

--- a/apps/admin/app/(dashboard)/terms/page.tsx
+++ b/apps/admin/app/(dashboard)/terms/page.tsx
@@ -7,10 +7,10 @@ export default async function TermsPage() {
     <dl className="">
       {terms.map(({ readings, synonyms, term }) => (
         <div
-          className="space-y-4 border-secondary-blue px-2 py-4 not-last:border-b"
+          className="space-y-4 border-secondary-blue not-last:border-b px-2 py-4"
           key={term}
         >
-          <dt className="text-lg font-semibold">{term}</dt>
+          <dt className="font-semibold text-lg">{term}</dt>
           <dd className="grid grid-cols-2 gap-2">
             <form action="" encType="multipart/form-data" method="post">
               {[...(synonyms ?? []), ''].map((synonym) => (

--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -15,7 +15,7 @@ export default function Login() {
         action={signIn}
         className="grid w-full max-w-md gap-8 rounded-lg border border-slate-400 bg-white/60 p-6 shadow-sm backdrop-blur"
       >
-        <GenericErrorMessage className="rounded-md bg-secondary-pink p-2 leading-normal text-slate-50" />
+        <GenericErrorMessage className="rounded-md bg-secondary-pink p-2 text-slate-50 leading-normal" />
 
         <div className="space-y-4">
           <FormField className="flex flex-col space-y-2" name="email">
@@ -28,7 +28,7 @@ export default function Login() {
               required
               type="email"
             />
-            <ErrorMessage className="text-sm leading-normal text-secondary-pink" />
+            <ErrorMessage className="text-secondary-pink text-sm leading-normal" />
           </FormField>
           <FormField className="flex flex-col space-y-2" name="password">
             <Label className="aria-disabled:cursor-not-allowed aria-disabled:text-slate-400">
@@ -41,12 +41,12 @@ export default function Login() {
               required
               type="password"
             />
-            <ErrorMessage className="text-sm leading-normal text-secondary-pink" />
+            <ErrorMessage className="text-secondary-pink text-sm leading-normal" />
           </FormField>
         </div>
 
         <Button
-          className="rounded-md bg-secondary-blue p-1 font-semibold text-slate-50 hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:outline-none active:bg-blue-600 active:shadow-inner disabled:pointer-events-none disabled:bg-blue-400"
+          className="rounded-md bg-secondary-blue p-1 font-semibold text-slate-50 hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 active:bg-blue-600 active:shadow-inner disabled:pointer-events-none disabled:bg-blue-400"
           type="submit"
         >
           ログイン

--- a/apps/web/app/channels/[slug]/page.tsx
+++ b/apps/web/app/channels/[slug]/page.tsx
@@ -72,7 +72,7 @@ export default async function ChannelSchedulePage({
       }
       title={channel.name}
     >
-      <h2 className="text-xl font-semibold">今後の配信予定</h2>
+      <h2 className="font-semibold text-xl">今後の配信予定</h2>
 
       {videos.length > 0 ? (
         <Timeline channels={[channel]} prefetchedData={videos} />

--- a/apps/web/app/channels/[slug]/videos/[[...queries]]/page.tsx
+++ b/apps/web/app/channels/[slug]/videos/[[...queries]]/page.tsx
@@ -88,7 +88,7 @@ export default async function VideosPage({
 
   return (
     <>
-      <h1 className="text-xl font-semibold">{title}</h1>
+      <h1 className="font-semibold text-xl">{title}</h1>
 
       <SearchResults
         channels={[channel]}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -68,7 +68,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <form action={search} className="contents">
               <SearchTextField
                 aria-label="検索"
-                className="appearance-none rounded-full border-0 bg-774-nevy-100 bg-search-icon bg-[size:1.5em] bg-[0.6em_center] bg-no-repeat py-1.5 pr-4 pl-[2.25em] text-774-nevy-300 placeholder:text-774-nevy-300 hover:bg-774-nevy-200 hover:text-primary focus:outline-0 focus-visible:bg-774-nevy-200 focus-visible:text-primary focus-visible:placeholder:text-774-nevy-400 dark:bg-zinc-700 dark:bg-search-icon-invert dark:text-774-nevy-100 dark:placeholder:text-774-nevy-200 dark:hover:bg-zinc-600 dark:hover:text-774-nevy-100 dark:focus-visible:bg-zinc-600 dark:focus-visible:text-774-nevy-100 dark:focus-visible:placeholder:text-774-nevy-100"
+                className="appearance-none rounded-full border-0 bg-774-nevy-100 bg-[0.6em_center] bg-[size:1.5em] bg-search-icon bg-no-repeat py-1.5 pr-4 pl-[2.25em] text-774-nevy-300 placeholder:text-774-nevy-300 hover:bg-774-nevy-200 hover:text-primary focus:outline-0 focus-visible:bg-774-nevy-200 focus-visible:text-primary focus-visible:placeholder:text-774-nevy-400 dark:bg-search-icon-invert dark:bg-zinc-700 dark:text-774-nevy-100 dark:focus-visible:bg-zinc-600 dark:focus-visible:text-774-nevy-100 dark:hover:bg-zinc-600 dark:hover:text-774-nevy-100 dark:placeholder:text-774-nevy-200 dark:focus-visible:placeholder:text-774-nevy-100"
                 name="query"
                 placeholder="検索"
                 type="search"
@@ -81,7 +81,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <TimerProvider>{children}</TimerProvider>
         </div>
 
-        <footer className="bg-primary py-5 text-sm text-primary-foreground dark:bg-zinc-800">
+        <footer className="bg-primary py-5 text-primary-foreground text-sm dark:bg-zinc-800">
           <nav className="mx-auto max-w-6xl px-4 py-2">
             <ul className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-end">
               <li>

--- a/apps/web/app/videos/[[...queries]]/loading.tsx
+++ b/apps/web/app/videos/[[...queries]]/loading.tsx
@@ -3,7 +3,7 @@ import { SearchResultsSkeleton } from '@/components/search-results'
 export default function Loading() {
   return (
     <>
-      <h1 className="text-xl font-semibold">
+      <h1 className="font-semibold text-xl">
         <span className="inline-block h-8 w-64 animate-pulse rounded-md bg-774-nevy-100 dark:bg-zinc-800" />
       </h1>
 

--- a/apps/web/app/videos/[[...queries]]/page.tsx
+++ b/apps/web/app/videos/[[...queries]]/page.tsx
@@ -65,7 +65,7 @@ export default async function VideosPage({
 
   return (
     <>
-      <h1 className="text-xl font-semibold">{title}</h1>
+      <h1 className="font-semibold text-xl">{title}</h1>
 
       <SearchResults prefetchedData={[videos]} query={query} />
     </>

--- a/apps/web/components/no-results.tsx
+++ b/apps/web/components/no-results.tsx
@@ -12,7 +12,7 @@ export default function NoResults({
 }) {
   return (
     <div className="space-y-8 px-8 py-16 text-center">
-      {title && <h1 className="text-2xl font-bold">{title}</h1>}
+      {title && <h1 className="font-bold text-2xl">{title}</h1>}
 
       <p className="text-balance">{message}</p>
 

--- a/apps/web/components/simple-document.tsx
+++ b/apps/web/components/simple-document.tsx
@@ -17,7 +17,7 @@ export default function SimpleDocument({
       {title && (
         <div className="bg-primary text-primary-foreground dark:bg-zinc-800">
           <div className="mx-auto max-w-6xl space-y-8 px-4 py-16">
-            <h1 className="text-3xl font-bold">{title}</h1>
+            <h1 className="font-bold text-3xl">{title}</h1>
 
             {button}
           </div>

--- a/apps/web/components/timeline.tsx
+++ b/apps/web/components/timeline.tsx
@@ -22,7 +22,7 @@ function TimelineSection({
 
   return (
     <section className="space-y-6">
-      <h2 className="text-right text-2xl font-bold">
+      <h2 className="text-right font-bold text-2xl">
         <time dateTime={dateTime.toJSON()}>
           {dateTime.toLocaleString('ja-JP', {
             dateStyle: 'short',
@@ -39,7 +39,7 @@ function TimelineSection({
 export function TimelineSkeleton() {
   return (
     <section className="space-y-6">
-      <h2 className="text-right text-2xl font-bold">
+      <h2 className="text-right font-bold text-2xl">
         <span className="inline-block h-6 w-32 animate-pulse rounded-md bg-774-nevy-100" />
       </h2>
 

--- a/apps/web/components/video-card.tsx
+++ b/apps/web/components/video-card.tsx
@@ -51,7 +51,7 @@ export function VideoCardSkeleton() {
       </div>
 
       <div className="grid grow grid-rows-[1fr_auto] gap-6 p-2.5">
-        <h3 className="font-semibold break-all">
+        <h3 className="break-all font-semibold">
           <span className="inline-block h-4 w-full animate-pulse rounded-md bg-774-nevy-200 dark:bg-zinc-700" />
           <span className="inline-block h-4 w-full animate-pulse rounded-md bg-774-nevy-200 dark:bg-zinc-700" />
           <span className="inline-block h-4 w-28 animate-pulse rounded-md bg-774-nevy-200 dark:bg-zinc-700" />
@@ -97,14 +97,14 @@ export default function VideoCard({
         {duration.total({
           unit: 'second',
         }) > 0 && (
-          <span className="absolute bottom-0 left-0 m-2 inline-block rounded-md bg-slate-800/80 px-1.5 py-0.5 text-xs font-semibold text-white">
+          <span className="absolute bottom-0 left-0 m-2 inline-block rounded-md bg-slate-800/80 px-1.5 py-0.5 font-semibold text-white text-xs">
             <time dateTime={duration.toString()}>
               {formatDuration(duration)}
             </time>
           </span>
         )}
         <LiveNow
-          className="absolute top-0 right-0 m-2 inline-block rounded-md bg-774-pink-600 px-1.5 py-0.5 text-xs font-semibold text-774-pink-50"
+          className="absolute top-0 right-0 m-2 inline-block rounded-md bg-774-pink-600 px-1.5 py-0.5 font-semibold text-774-pink-50 text-xs"
           duration={duration}
           publishedAt={publishedAt}
         />
@@ -112,7 +112,7 @@ export default function VideoCard({
 
       <div className="grid grow grid-rows-[1fr_auto] gap-6 p-2.5">
         <h3
-          className="line-clamp-3 font-semibold break-all"
+          className="line-clamp-3 break-all font-semibold"
           title={value.title}
         >
           {value.title}

--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,15 @@
       "complexity": {
         "useLiteralKeys": "off"
       },
+      "nursery": {
+        "useSortedClasses": {
+          "level": "warn",
+          "options": {
+            "attributes": ["className"],
+            "functions": ["twMerge"]
+          }
+        }
+      },
       "suspicious": {
         "noUnknownAtRules": "off"
       }


### PR DESCRIPTION
This pull request primarily refactors the ordering of Tailwind CSS utility classes in various components to ensure consistency and maintainability. It also introduces a new linting rule to warn about unsorted class names, helping enforce this style automatically. No functional or visual changes are introduced—only the order of classes in `className` attributes is adjusted.

Code quality improvements:

* Added a new Biome linting rule (`nursery.useSortedClasses`) to warn about unsorted Tailwind class names, specifying `className` attributes and `twMerge` functions as targets.

Styling consistency (Tailwind class order):

* Reordered Tailwind CSS classes in multiple components and pages, such as headings (`h1`, `h2`, `h3`), buttons, links, and form elements, to maintain a consistent class order throughout the codebase. [[1]](diffhunk://#diff-c7cafe4a1ba7687e8ef7f5735c72f7b2e6e1a1425cfa54cc59aa81037463d500L14-R20) [[2]](diffhunk://#diff-f6cb306c5b9029ed8179c9abe4f5d57a3e6171bd4f470b7edcff3a29e5544a1bL15-R15) [[3]](diffhunk://#diff-40c31e3fe3afb4e37452b7ca725c4a2e3e201472737b7ad72c8d2c1b43a2e950L10-R13) [[4]](diffhunk://#diff-fd74be528b36308a6d86166e1e570c48f6c0907671af4f31ac5eaac55282f2a8L18-R18) [[5]](diffhunk://#diff-fd74be528b36308a6d86166e1e570c48f6c0907671af4f31ac5eaac55282f2a8L31-R31) [[6]](diffhunk://#diff-fd74be528b36308a6d86166e1e570c48f6c0907671af4f31ac5eaac55282f2a8L44-R49) [apps/web/app/channels/[slug]/page.tsxL75-R75](diffhunk://#diff-b05d1e8314b4ca80ced54f591a678ef6f5ad1413cfac58b50ce7604c5661542cL75-R75), [apps/web/app/channels/[slug]/videos/[[...queries]]/page.tsxL91-R91](diffhunk://#diff-b2ed1e26e8d271e8c3bfa6132d89bfea15aea37b3851e03ff9197da04a0705c3L91-R91), [[7]](diffhunk://#diff-c235c52626fe2cfbb53241bb015bdd7b5f5a28f9a10a08e1f401238e773fa7adL71-R71) [[8]](diffhunk://#diff-c235c52626fe2cfbb53241bb015bdd7b5f5a28f9a10a08e1f401238e773fa7adL84-R84) [apps/web/app/videos/[[...queries]]/loading.tsxL6-R6](diffhunk://#diff-7715d510315e57106704bffd7f0c6d1fb961b1905121e6fb80687c52d0aa03a7L6-R6), [apps/web/app/videos/[[...queries]]/page.tsxL68-R68](diffhunk://#diff-869509d2a50caad9b1978935673bd5e75ab326ca753ba072e724b4f8c187d03fL68-R68), [[9]](diffhunk://#diff-9228f2eacbcf123815c73cb2ecd838d76ad25af2803bae0c7ad506f04720a1cdL15-R15) [[10]](diffhunk://#diff-5c55aeb88a77818b22a874714f1bc85150d32a0a1526bd76f0336b89da88de4aL20-R20) [[11]](diffhunk://#diff-4e24b388b81764599cbbf2e5daa9c3da893abb67650bc7393acc8d6a3e5b8ca5L25-R25) [[12]](diffhunk://#diff-4e24b388b81764599cbbf2e5daa9c3da893abb67650bc7393acc8d6a3e5b8ca5L42-R42) [[13]](diffhunk://#diff-8ed8493e0d78b3a11e2175c8918b5abb431316db38f39ae4da349ad75410c57dL54-R54) [[14]](diffhunk://#diff-8ed8493e0d78b3a11e2175c8918b5abb431316db38f39ae4da349ad75410c57dL100-R115)