### PR TITLE
fix(admin): disable cache for redis

### DIFF
--- a/apps/admin/lib/redis.ts
+++ b/apps/admin/lib/redis.ts
@@ -1,5 +1,3 @@
 import { Redis } from '@upstash/redis'
 
-export const redisClient = Redis.fromEnv({
-  cache: 'default',
-})
+export const redisClient = Redis.fromEnv()


### PR DESCRIPTION
This pull request makes a small change to the Redis client initialization in the `apps/admin/lib/redis.ts` file. The change removes the explicit `cache: 'default'` option from the `Redis.fromEnv` call, simplifying the client setup.