### PR TITLE
fix(admin): rename class from 'recharts-wrapper' to 'recharts-surface'

### DIFF
--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -72,6 +72,6 @@
   }
 }
 
-.recharts-wrapper:focus:not(:focus-visible) {
+.recharts-surface:focus:not(:focus-visible) {
   outline: none;
 }


### PR DESCRIPTION
This pull request makes a minor update to a CSS selector to improve accessibility handling for chart components.

- Changed the selector from `.recharts-wrapper` to `.recharts-surface` for the focus-visible outline rule, ensuring that outlines are only removed for the correct chart element.