### PR TITLE
feat(web): update `fetchSuggestions` to allow empty query

### DIFF
--- a/apps/web/app/@modal/(.)search/_components/suggestions.tsx
+++ b/apps/web/app/@modal/(.)search/_components/suggestions.tsx
@@ -4,7 +4,7 @@ import type { searchParamsSchema } from '../_lib/search-params-schema'
 import { SearchModalLink } from './search-modal'
 
 async function fetchSuggestions(query: string) {
-  if (!query || query.length === 0) {
+  if (!query) {
     return []
   }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the suggestions fetching logic in the search modal. The change ensures that suggestions are only fetched when the query is non-empty, rather than requiring a minimum length of two characters.

* Updated the condition in `fetchSuggestions` in `apps/web/app/@modal/(.)search/_components/suggestions.tsx` to allow fetching suggestions for any non-empty query, instead of requiring at least two characters.