### PR TITLE
feat: add new tables

### DIFF
--- a/apps/batch/app/videos/check/route.ts
+++ b/apps/batch/app/videos/check/route.ts
@@ -83,7 +83,10 @@ type SoftDeleteRowsOptions = {
   currentDateTime: Temporal.Instant
   ids: string[]
   supabaseClient: TypedSupabaseClient
-  table: keyof Database['public']['Tables']
+  table: Exclude<
+    keyof Database['public']['Tables'],
+    'twitch_users' | 'twitch_videos' | 'youtube_channels' | 'youtube_videos'
+  >
 }
 
 async function softDeleteRows({

--- a/apps/batch/lib/scraper/db.ts
+++ b/apps/batch/lib/scraper/db.ts
@@ -59,6 +59,7 @@ export default class DB implements AsyncDisposable {
             created_at,
             deleted_at,
             duration,
+            platform,
             published_at,
             slug,
             thumbnail_id,

--- a/apps/batch/lib/scraper/scraper.ts
+++ b/apps/batch/lib/scraper/scraper.ts
@@ -428,6 +428,7 @@ export default class Scraper implements AsyncDisposable {
           created_at: this.#currentDateTime.toString(),
           deleted_at: null,
           duration: originalVideo.contentDetails.duration ?? 'P0D',
+          platform: 'youtube',
           published_at: publishedAt.toString(),
           slug: originalVideo.id,
           title: originalVideo.snippet.title ?? '',

--- a/packages/database/types/supabase.ts
+++ b/packages/database/types/supabase.ts
@@ -104,6 +104,58 @@ export type Database = {
         }
         Relationships: []
       }
+      twitch_users: {
+        Row: {
+          channel_id: string
+          twitch_login_name: string | null
+          twitch_user_id: string
+        }
+        Insert: {
+          channel_id: string
+          twitch_login_name?: string | null
+          twitch_user_id: string
+        }
+        Update: {
+          channel_id?: string
+          twitch_login_name?: string | null
+          twitch_user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'twitch_users_channel_id_fkey'
+            columns: ['channel_id']
+            isOneToOne: true
+            referencedRelation: 'channels'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      twitch_videos: {
+        Row: {
+          twitch_video_id: string
+          type: Database['public']['Enums']['twitch_video_type'] | null
+          video_id: string
+        }
+        Insert: {
+          twitch_video_id: string
+          type?: Database['public']['Enums']['twitch_video_type'] | null
+          video_id: string
+        }
+        Update: {
+          twitch_video_id?: string
+          type?: Database['public']['Enums']['twitch_video_type'] | null
+          video_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'twitch_videos_video_id_fkey'
+            columns: ['video_id']
+            isOneToOne: true
+            referencedRelation: 'videos'
+            referencedColumns: ['id']
+          },
+        ]
+      }
       videos: {
         Row: {
           channel_id: string
@@ -111,6 +163,7 @@ export type Database = {
           deleted_at: string | null
           duration: string
           id: string
+          platform: Database['public']['Enums']['platform_type'] | null
           published_at: string
           slug: string
           thumbnail_id: string | null
@@ -124,6 +177,7 @@ export type Database = {
           deleted_at?: string | null
           duration: string
           id?: string
+          platform?: Database['public']['Enums']['platform_type'] | null
           published_at: string
           slug: string
           thumbnail_id?: string | null
@@ -137,6 +191,7 @@ export type Database = {
           deleted_at?: string | null
           duration?: string
           id?: string
+          platform?: Database['public']['Enums']['platform_type'] | null
           published_at?: string
           slug?: string
           thumbnail_id?: string | null
@@ -157,6 +212,55 @@ export type Database = {
             columns: ['thumbnail_id']
             isOneToOne: false
             referencedRelation: 'thumbnails'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      youtube_channels: {
+        Row: {
+          channel_id: string
+          youtube_channel_id: string
+          youtube_handle: string | null
+        }
+        Insert: {
+          channel_id: string
+          youtube_channel_id: string
+          youtube_handle?: string | null
+        }
+        Update: {
+          channel_id?: string
+          youtube_channel_id?: string
+          youtube_handle?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'youtube_channels_channel_id_fkey'
+            columns: ['channel_id']
+            isOneToOne: true
+            referencedRelation: 'channels'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      youtube_videos: {
+        Row: {
+          video_id: string
+          youtube_video_id: string
+        }
+        Insert: {
+          video_id: string
+          youtube_video_id: string
+        }
+        Update: {
+          video_id?: string
+          youtube_video_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'youtube_videos_video_id_fkey'
+            columns: ['video_id']
+            isOneToOne: true
+            referencedRelation: 'videos'
             referencedColumns: ['id']
           },
         ]
@@ -190,6 +294,7 @@ export type Database = {
           deleted_at: string | null
           duration: string
           id: string
+          platform: Database['public']['Enums']['platform_type'] | null
           published_at: string
           slug: string
           thumbnail_id: string | null
@@ -212,7 +317,8 @@ export type Database = {
       }
     }
     Enums: {
-      [_ in never]: never
+      platform_type: 'youtube' | 'twitch'
+      twitch_video_type: 'vod' | 'clip' | 'highlight' | 'premiere' | 'upload'
     }
     CompositeTypes: {
       [_ in never]: never
@@ -339,6 +445,9 @@ export type CompositeTypes<
 
 export const Constants = {
   public: {
-    Enums: {},
+    Enums: {
+      platform_type: ['youtube', 'twitch'],
+      twitch_video_type: ['vod', 'clip', 'highlight', 'premiere', 'upload'],
+    },
   },
 } as const


### PR DESCRIPTION
This pull request introduces significant changes to the database schema to support platform-specific metadata for videos and channels, as well as updates to related application logic. The main focus is on adding support for YouTube and Twitch platforms, including new tables and enum types, and ensuring that platform information is captured and used throughout the codebase.

**Database schema updates:**

* Added new tables: `twitch_users`, `twitch_videos`, `youtube_channels`, and `youtube_videos`, each with their respective fields and relationships to the main `channels` and `videos` tables. [[1]](diffhunk://#diff-1641861beaab4746ee470004803d0c109d5e5cc1041dd4354acb0af6f855791eR107-R166) [[2]](diffhunk://#diff-1641861beaab4746ee470004803d0c109d5e5cc1041dd4354acb0af6f855791eR219-R267)
* Introduced new enum types: `platform_type` (values: 'youtube', 'twitch') and `twitch_video_type` (values: 'vod', 'clip', 'highlight', 'premiere', 'upload'). [[1]](diffhunk://#diff-1641861beaab4746ee470004803d0c109d5e5cc1041dd4354acb0af6f855791eL215-R321) [[2]](diffhunk://#diff-1641861beaab4746ee470004803d0c109d5e5cc1041dd4354acb0af6f855791eL342-R451)
* Added a new `platform` field to the `videos` table and its related insert/update types to track the platform of each video. [[1]](diffhunk://#diff-1641861beaab4746ee470004803d0c109d5e5cc1041dd4354acb0af6f855791eR180) [[2]](diffhunk://#diff-1641861beaab4746ee470004803d0c109d5e5cc1041dd4354acb0af6f855791eR194) [[3]](diffhunk://#diff-1641861beaab4746ee470004803d0c109d5e5cc1041dd4354acb0af6f855791eR297)

**Application logic updates:**

* Updated the `DB` class in `apps/batch/lib/scraper/db.ts` to include the `platform` field when handling video records.
* Modified the `Scraper` class in `apps/batch/lib/scraper/scraper.ts` to set the `platform` field to `'youtube'` when creating video records for YouTube.
* Changed the `SoftDeleteRowsOptions` type in `apps/batch/app/videos/check/route.ts` to exclude platform-specific tables (`twitch_users`, `twitch_videos`, `youtube_channels`, `youtube_videos`) from soft delete operations.