### PR TITLE
build(ui): remove vercel.json

### DIFF
--- a/packages/ui/vercel.json
+++ b/packages/ui/vercel.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "cd ../.. && pnpm install && cd packages/ui && pnpm build-storybook",
-  "framework": null,
-  "ignoreCommand": "npx turbo-ignore",
-  "installCommand": "echo 'Skipping install, done in buildCommand'",
-  "outputDirectory": "storybook-static"
-}


### PR DESCRIPTION
This pull request removes the Vercel deployment configuration for the `packages/ui` package. This means the Storybook build for UI components will no longer be automatically deployed via Vercel.

Deployment configuration removal:

* Deleted the `vercel.json` file from `packages/ui`, which disables automatic Storybook deployment and related build/install commands.