### PR TITLE
feat(web): use `videos.status`

### DIFF
--- a/apps/admin/app/(dashboard)/videos/[id]/page.tsx
+++ b/apps/admin/app/(dashboard)/videos/[id]/page.tsx
@@ -10,6 +10,7 @@ import { notFound } from 'next/navigation'
 import { Temporal } from 'temporal-polyfill'
 import { ChevronLeftIcon, ExternalLinkIcon } from '@/components/icons'
 import { supabaseClient } from '@/lib/supabase/public'
+import { StatusBadge } from '../_components/status-badge'
 import getVideo from '../_lib/get-video'
 import { SyncVideoButton } from './_components/sync-video-button'
 import { VideoActionsButtons } from './_components/video-actions-buttons'
@@ -156,7 +157,7 @@ export default async function VideoDetailPage({ params }: Props) {
                 ステータス
               </h3>
             </div>
-            <div className="border-gray-200 border-t px-4 py-5 sm:px-6">
+            <div className="flex gap-2 border-gray-200 border-t px-4 py-5 sm:px-6">
               <span
                 className={`inline-flex rounded-full px-2 py-1 font-semibold text-xs leading-5 ${getStatusColor(
                   video,
@@ -164,6 +165,8 @@ export default async function VideoDetailPage({ params }: Props) {
               >
                 {getStatusText(video)}
               </span>
+
+              <StatusBadge status={video.status} />
             </div>
           </div>
         </div>

--- a/apps/admin/app/(dashboard)/videos/_components/status-badge.tsx
+++ b/apps/admin/app/(dashboard)/videos/_components/status-badge.tsx
@@ -1,0 +1,29 @@
+import type { Tables } from '@shinju-date/database'
+import { twMerge } from 'tailwind-merge'
+
+type VideoStatus = Tables<'videos'>['status']
+
+const STATUS_LABELS: Record<VideoStatus, string> = {
+  ENDED: '公開済み',
+  LIVE: '配信中',
+  UPCOMING: '待機中',
+}
+
+const STATUS_COLORS: Record<VideoStatus, string> = {
+  ENDED: 'bg-gray-100 text-gray-800 ring-gray-600/20',
+  LIVE: 'bg-red-100 text-red-800 ring-red-600/20',
+  UPCOMING: 'bg-blue-100 text-blue-800 ring-blue-600/20',
+}
+
+export function StatusBadge({ status }: { status: VideoStatus }) {
+  return (
+    <span
+      className={twMerge(
+        `inline-flex items-center rounded-md px-2 py-1 font-medium text-xs ring-1 ring-inset`,
+        STATUS_COLORS[status] ?? STATUS_COLORS['ENDED'],
+      )}
+    >
+      {STATUS_LABELS[status] ?? status}
+    </span>
+  )
+}

--- a/apps/admin/app/(dashboard)/videos/_components/video-list.tsx
+++ b/apps/admin/app/(dashboard)/videos/_components/video-list.tsx
@@ -24,6 +24,7 @@ import {
 } from '../_actions'
 import type { Video } from '../_lib/get-videos'
 import { SortIcon } from './sort-icon'
+import { StatusBadge } from './status-badge'
 
 type Props = {
   videos: Video[]
@@ -298,18 +299,22 @@ export default function VideoList({ videos }: Props) {
                   </td>
                   <td className="p-3">{formatNumber(video.clicks)}</td>
                   <td className="p-3">
-                    <span
-                      className={twMerge(
-                        'whitespace-nowrap rounded px-2 py-1 text-xs',
-                        video.deleted_at
-                          ? 'bg-red-100 text-red-800'
-                          : video.visible
-                            ? 'bg-green-100 text-green-800'
-                            : 'bg-gray-100 text-gray-800',
-                      )}
-                    >
-                      {getStatusText(video)}
-                    </span>
+                    <div className="flex flex-col items-center gap-2">
+                      <span
+                        className={twMerge(
+                          'whitespace-nowrap rounded px-2 py-1 text-xs',
+                          video.deleted_at
+                            ? 'bg-red-100 text-red-800'
+                            : video.visible
+                              ? 'bg-green-100 text-green-800'
+                              : 'bg-gray-100 text-gray-800',
+                        )}
+                      >
+                        {getStatusText(video)}
+                      </span>
+
+                      <StatusBadge status={video.status} />
+                    </div>
                   </td>
                   <td className="p-3">
                     <DropdownMenu>

--- a/apps/admin/app/(dashboard)/videos/_lib/get-video.ts
+++ b/apps/admin/app/(dashboard)/videos/_lib/get-video.ts
@@ -1,4 +1,5 @@
 import { REDIS_KEYS, TIME_ZONE } from '@shinju-date/constants'
+import type { Tables } from '@shinju-date/database'
 import { range } from '@shinju-date/helpers'
 import { formatDate } from '@shinju-date/temporal-fns'
 import { cache } from 'react'
@@ -14,6 +15,7 @@ export type VideoDetail = {
   published_at: string
   updated_at: string
   created_at: string
+  status: Tables<'videos'>['status']
   duration: string
   thumbnail: {
     path: string
@@ -37,7 +39,7 @@ const getVideo = cache(async function getVideo(
   const { data: video, error } = await supabaseClient
     .from('videos')
     .select(
-      'id, title, visible, deleted_at, published_at, updated_at, created_at, duration, thumbnail:thumbnails(path, blur_data_url), talent:channels(id, name), youtube_video:youtube_videos(youtube_video_id)',
+      'id, title, visible, deleted_at, published_at, updated_at, created_at, status, duration, thumbnail:thumbnails(path, blur_data_url), talent:channels(id, name), youtube_video:youtube_videos(youtube_video_id)',
     )
     .eq('id', id)
     .single()
@@ -91,6 +93,7 @@ const getVideo = cache(async function getVideo(
     duration: video.duration,
     id: video.id,
     published_at: video.published_at,
+    status: video.status,
     talent: video.talent,
     thumbnail: video.thumbnail,
     title: video.title,

--- a/apps/admin/app/(dashboard)/videos/_lib/get-videos.ts
+++ b/apps/admin/app/(dashboard)/videos/_lib/get-videos.ts
@@ -1,4 +1,5 @@
 import { REDIS_KEYS, TIME_ZONE } from '@shinju-date/constants'
+import type { Tables } from '@shinju-date/database'
 import { range } from '@shinju-date/helpers'
 import { formatDate } from '@shinju-date/temporal-fns'
 import { Temporal } from 'temporal-polyfill'
@@ -13,6 +14,7 @@ export type Video = {
   deleted_at: string | null
   published_at: string
   updated_at: string
+  status: Tables<'videos'>['status']
   duration: string
   thumbnail: {
     path: string
@@ -57,7 +59,7 @@ export async function getVideos(
   let query = supabaseClient
     .from('videos')
     .select(
-      'id, title, visible, deleted_at, published_at, updated_at, duration, thumbnail:thumbnails(path, blur_data_url), talent:channels(id, name), youtube_video:youtube_videos(youtube_video_id)',
+      'id, title, visible, deleted_at, published_at, updated_at, status, duration, thumbnail:thumbnails(path, blur_data_url), talent:channels(id, name), youtube_video:youtube_videos(youtube_video_id)',
       { count: 'exact' },
     )
 
@@ -134,6 +136,7 @@ export async function getVideos(
     duration: video.duration,
     id: video.id,
     published_at: video.published_at,
+    status: video.status,
     talent: video.talent,
     thumbnail: video.thumbnail,
     title: video.title,

--- a/apps/web/components/live-now.tsx
+++ b/apps/web/components/live-now.tsx
@@ -1,62 +1,13 @@
-'use client'
-
-import { useEffect, useState } from 'react'
-import { Temporal } from 'temporal-polyfill'
-import { useNow } from './timer'
-
-function isActive({
-  duration,
-  now,
-  publishedAt,
-}: {
-  duration: Temporal.Duration
-  now: Temporal.ZonedDateTime
-  publishedAt: Temporal.ZonedDateTime
-}): boolean {
-  return (
-    Temporal.ZonedDateTime.compare(publishedAt, now) < 1 &&
-    Temporal.ZonedDateTime.compare(
-      now,
-      publishedAt.add({
-        hours: 12,
-      }),
-    ) < 1 &&
-    duration.total({
-      unit: 'second',
-    }) < 1 &&
-    (publishedAt.epochMilliseconds / 1_000) % 60 > 0
-  )
-}
+import type { Tables } from '@shinju-date/database'
 
 export default function LiveNow({
   className,
-  duration,
-  publishedAt,
+  status,
 }: {
   className?: string | undefined
-  duration: Temporal.Duration
-  publishedAt: Temporal.ZonedDateTime
+  status: Tables<'videos'>['status']
 }) {
-  const now = useNow()
-  const [liveNow, setLiveNow] = useState(() =>
-    isActive({
-      duration,
-      now,
-      publishedAt,
-    }),
-  )
-
-  useEffect(() => {
-    setLiveNow(() =>
-      isActive({
-        duration,
-        now,
-        publishedAt,
-      }),
-    )
-  }, [now, publishedAt, duration])
-
-  if (!liveNow) {
+  if (status !== 'LIVE') {
     return null
   }
 

--- a/apps/web/components/video-card.tsx
+++ b/apps/web/components/video-card.tsx
@@ -119,8 +119,7 @@ export default function VideoCard({
         )}
         <LiveNow
           className="absolute top-0 right-0 m-2 inline-block rounded-md bg-774-pink-600 px-1.5 py-0.5 font-semibold text-774-pink-50 text-xs"
-          duration={duration}
-          publishedAt={publishedAt}
+          status={value.status}
         />
       </div>
 


### PR DESCRIPTION
This pull request introduces a refactor to how video status is handled and displayed across both the admin and web applications. The main change is the adoption of a normalized `status` field from the database (`Tables<'videos'>['status']`) to represent the state of a video (e.g., LIVE, ENDED, UPCOMING), which is now consistently used in UI components and data fetching logic. This results in simplified logic for determining live videos and improved UI consistency.

### Video Status Refactor and UI Improvements

**Data Model and Fetching:**
* Added the `status` field to the `Video` and `VideoDetail` types and ensured it is fetched from the database in both `getVideo` and `getVideos` functions. This allows all parts of the app to reliably reference video status. [[1]](diffhunk://#diff-4f4124911530e1e3fdc2cca6b4dc62f72e3c1d6f0945146264e8631d55c024cfR18) [[2]](diffhunk://#diff-4f4124911530e1e3fdc2cca6b4dc62f72e3c1d6f0945146264e8631d55c024cfL40-R42) [[3]](diffhunk://#diff-4f4124911530e1e3fdc2cca6b4dc62f72e3c1d6f0945146264e8631d55c024cfR96) [[4]](diffhunk://#diff-7d8b2358e1a93cbe38cc379184f3dc106be4c39113c27854f12bde9837d97662R17) [[5]](diffhunk://#diff-7d8b2358e1a93cbe38cc379184f3dc106be4c39113c27854f12bde9837d97662L60-R62) [[6]](diffhunk://#diff-7d8b2358e1a93cbe38cc379184f3dc106be4c39113c27854f12bde9837d97662R139) [[7]](diffhunk://#diff-300a485c6ded82136851a8047e37e000dae5f77606c87167223fe7d113f2c5adL4-R15) [[8]](diffhunk://#diff-300a485c6ded82136851a8047e37e000dae5f77606c87167223fe7d113f2c5adL36-R58)

**UI Components:**
* Introduced a reusable `StatusBadge` component to visually display the video status with appropriate labels and colors, and integrated it into both the admin video detail and video list pages. [[1]](diffhunk://#diff-27cec9e75fb98a7b9bb1bc79e75336c0c1657598a36448cd20ac6367e1c4518aR1-R29) [apps/admin/app/(dashboard)/videos/[id]/page.tsxR13](diffhunk://#diff-ed2cf6a967af0f529992430fc1d4c822e919ea847d659f2a05a22b9f708f006fR13), [apps/admin/app/(dashboard)/videos/[id]/page.tsxL159-R169](diffhunk://#diff-ed2cf6a967af0f529992430fc1d4c822e919ea847d659f2a05a22b9f708f006fL159-R169), [[2]](diffhunk://#diff-ade5e804072da2b87f5045c757bbe50ac19524f979dc9f7c8136cdd419a86824R27) [[3]](diffhunk://#diff-ade5e804072da2b87f5045c757bbe50ac19524f979dc9f7c8136cdd419a86824R302) [[4]](diffhunk://#diff-ade5e804072da2b87f5045c757bbe50ac19524f979dc9f7c8136cdd419a86824R315-R317)
* Updated the `LiveNow` component to use the normalized `status` field instead of custom logic based on time and duration, simplifying the determination of live videos. [[1]](diffhunk://#diff-5ff81d37a353e5370a8c4ded2d744e7024f5cf23be443dd78415f2f4bf1aa231L1-R10) [[2]](diffhunk://#diff-8ed8493e0d78b3a11e2175c8918b5abb431316db38f39ae4da349ad75410c57dL122-R122)

**Query Logic Simplification:**
* Refactored the logic for fetching not-ended videos in `fetchNotEndedVideos` to filter by the new `status` field instead of complex time and duration calculations, improving maintainability and performance.

These changes streamline how video status is handled throughout the codebase, making it easier to maintain and extend in the future.