### PR TITLE
fix(batch): fix status assignment logic in scraper.ts

### DIFF
--- a/apps/batch/lib/scraper/scraper.ts
+++ b/apps/batch/lib/scraper/scraper.ts
@@ -394,6 +394,8 @@ export default class Scraper implements AsyncDisposable {
               updateValue.status = status
 
               detectUpdate = true
+            } else {
+              updateValue.status = savedVideo.status
             }
 
             if (savedVideo.duration !== newDuration) {


### PR DESCRIPTION
This pull request introduces a minor update to the `Scraper` class to ensure that the `updateValue.status` field is correctly set when a video update is detected or not. The change improves data consistency when processing video status updates.

* Ensures that `updateValue.status` is set to the value from `savedVideo.status` if no update is detected, maintaining accurate status information in the `Scraper` class.