### PR TITLE
feat(web): implement GET route for fetching signed thumbnail URLs

### DIFF
--- a/apps/web/app/images/thumbnails/[id]/route.ts
+++ b/apps/web/app/images/thumbnails/[id]/route.ts
@@ -1,0 +1,59 @@
+import { createErrorResponse } from '@shinju-date/helpers'
+import { type NextRequest, NextResponse } from 'next/server'
+import { createSupabaseClient } from '@/lib/supabase'
+
+const SIGNED_URL_EXPIRES_IN = 60 * 10 // 10 minutes
+
+const supabaseAdminClient = createSupabaseClient(
+  undefined,
+  process.env['SUPABASE_SERVICE_ROLE_KEY'],
+)
+
+export async function GET(
+  request: NextRequest,
+  ctx: RouteContext<'/images/thumbnails/[id]'>,
+) {
+  const { id } = await ctx.params
+  const { data: thumbnail, error } = await supabaseAdminClient
+    .from('thumbnails')
+    .select('path')
+    .eq('id', id)
+    .is('deleted_at', null)
+    .maybeSingle()
+
+  if (error || !thumbnail) {
+    return createErrorResponse('Failed to fetch thumbnail', { status: 404 })
+  }
+
+  const { data, error: signedUrlError } = await supabaseAdminClient.storage
+    .from('thumbnails')
+    .createSignedUrl(thumbnail.path, SIGNED_URL_EXPIRES_IN)
+
+  if (signedUrlError) {
+    return createErrorResponse('Failed to create signed URL', { status: 500 })
+  }
+
+  const fetchHeaders = new Headers(request.headers)
+
+  fetchHeaders.delete('Host')
+  fetchHeaders.delete('Cookie')
+
+  const res = await fetch(data.signedUrl, {
+    headers: fetchHeaders,
+  })
+  const headers = new Headers({
+    'Accept-Ranges': res.headers.get('Accept-Ranges') || 'none',
+    'Cache-Control': `public, max-age=${SIGNED_URL_EXPIRES_IN}`,
+    'Content-Type': res.headers.get('Content-Type') || 'image/jpeg',
+  })
+  const contentLength = res.headers.get('Content-Length')
+
+  if (contentLength) {
+    headers.set('Content-Length', contentLength)
+  }
+
+  return new NextResponse(res.body, {
+    headers,
+    status: res.status,
+  })
+}

--- a/apps/web/components/video-card.tsx
+++ b/apps/web/components/video-card.tsx
@@ -2,7 +2,6 @@ import Image from 'next/image'
 import { Temporal } from 'temporal-polyfill'
 import { timeZone } from '@/lib/constants'
 import type { Video } from '@/lib/fetchers'
-import { supabaseClient } from '@/lib/supabase'
 import FormattedTime from './formatted-time'
 import LiveNow from './live-now'
 
@@ -20,13 +19,10 @@ function getThumbnailURL(
     ]
   }
 
-  const {
-    data: { publicUrl: url },
-  } = supabaseClient.storage
-    .from('thumbnails')
-    .getPublicUrl(video.thumbnail.path)
-
-  return [url, video.thumbnail.blur_data_url]
+  return [
+    `/images/thumbnails/${video.thumbnail.id}`,
+    video.thumbnail.blur_data_url,
+  ]
 }
 
 function formatDuration(duration: Temporal.Duration): string {

--- a/apps/web/lib/fetchers.ts
+++ b/apps/web/lib/fetchers.ts
@@ -12,7 +12,7 @@ const DEFAULT_SEARCH_SELECT = `
   published_at,
   status,
   talent:channels!inner (id, name),
-  thumbnail:thumbnails (blur_data_url, height, path, width),
+  thumbnail:thumbnails (blur_data_url, height, id, path, width),
   title,
   youtube_video:youtube_videos!inner (youtube_video_id)
 `
@@ -21,7 +21,7 @@ export type Talent = Pick<Tables<'channels'>, 'id' | 'name'>
 
 export type Thumbnail = Pick<
   Tables<'thumbnails'>,
-  'blur_data_url' | 'height' | 'path' | 'width'
+  'blur_data_url' | 'height' | 'id' | 'path' | 'width'
 >
 
 export type Video = Pick<

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,11 +4,6 @@ import { withSentryConfig } from '@sentry/nextjs'
 // import remarkGfm from 'remark-gfm'
 import type { NextConfig } from 'next'
 
-const supabaseBaseURL =
-  typeof process.env['NEXT_PUBLIC_SUPABASE_URL'] !== 'undefined'
-    ? new URL(process.env['NEXT_PUBLIC_SUPABASE_URL'])
-    : undefined
-
 const nextConfig: NextConfig = {
   // cacheComponents: true,
   headers() {
@@ -44,19 +39,6 @@ const nextConfig: NextConfig = {
     formats: ['image/avif', 'image/webp'],
     minimumCacheTTL: 365 * 24 * 60 * 60,
     remotePatterns: [
-      ...(supabaseBaseURL
-        ? [
-            {
-              hostname: supabaseBaseURL.host,
-              pathname: '/storage/v1/object/public/**',
-              ...(supabaseBaseURL.protocol === 'https:'
-                ? {
-                    protocol: 'https' as const,
-                  }
-                : {}),
-            },
-          ]
-        : []),
       {
         hostname: 'i.ytimg.com',
         pathname: '/vi/**',


### PR DESCRIPTION
This pull request introduces a new API route for serving thumbnail images via signed URLs and refactors how thumbnails are accessed throughout the app for improved security and cache control. The main changes include adding the `/images/thumbnails/[id]` route to proxy thumbnail requests, updating frontend components to use this route, and adjusting Supabase client creation for more flexible cache revalidation. Additionally, the thumbnail type and query now include the `id` field, and unused remote image patterns were removed from the Next.js config.

**Thumbnail serving and API integration:**

* Added a new API route `apps/web/app/images/thumbnails/[id]/route.ts` to fetch thumbnail metadata from Supabase, create a signed URL, and proxy the image response with appropriate headers. This secures direct access to thumbnails and enables cache control. ([apps/web/app/images/thumbnails/[id]/route.tsR1-R54](diffhunk://#diff-f33ed442e1075a11e4cd36a9ab1804de2787e8c05f06e66da1429e8da76db7e4R1-R54))
* Updated `getThumbnailURL` in `apps/web/components/video-card.tsx` to use the new API route instead of direct public URLs, improving security and consistency.

**Supabase client and type updates:**

* Refactored Supabase client creation in `apps/web/lib/supabase.ts` to export `createSupabaseClient` and adjust cache revalidation based on resource type, supporting more granular caching for thumbnails and announcements. [[1]](diffhunk://#diff-272600cb697f45446164744f4baeb35bb3dd0e81b2a4f4ed1f1f6ad3172423deL3-R3) [[2]](diffhunk://#diff-272600cb697f45446164744f4baeb35bb3dd0e81b2a4f4ed1f1f6ad3172423deL32-R52) [[3]](diffhunk://#diff-272600cb697f45446164744f4baeb35bb3dd0e81b2a4f4ed1f1f6ad3172423deL58-R61)
* Added the `id` field to the thumbnail type and database query in `apps/web/lib/fetchers.ts` to support the new thumbnail API route. [[1]](diffhunk://#diff-300a485c6ded82136851a8047e37e000dae5f77606c87167223fe7d113f2c5adL15-R15) [[2]](diffhunk://#diff-300a485c6ded82136851a8047e37e000dae5f77606c87167223fe7d113f2c5adL24-R24)

**Configuration cleanup:**

* Removed unused Supabase remote image patterns from the Next.js config in `apps/web/next.config.ts`, as thumbnails are now proxied through the new API route. [[1]](diffhunk://#diff-6b13ed47afb6968d423f855cd247d64a6bd145c369f944ddb742353b319ee2a2L7-L11) [[2]](diffhunk://#diff-6b13ed47afb6968d423f855cd247d64a6bd145c369f944ddb742353b319ee2a2L47-L59)