### PR TITLE
feat(database): add `twitch_user_id` and `youtube_channel_id` fields to video types

### DIFF
--- a/packages/database/types/supabase.ts
+++ b/packages/database/types/supabase.ts
@@ -196,23 +196,33 @@ export type Database = {
       twitch_videos: {
         Row: {
           id: string
+          twitch_user_id: string
           twitch_video_id: string
           type: Database['public']['Enums']['twitch_video_type'] | null
           video_id: string
         }
         Insert: {
           id?: string
+          twitch_user_id: string
           twitch_video_id: string
           type?: Database['public']['Enums']['twitch_video_type'] | null
           video_id: string
         }
         Update: {
           id?: string
+          twitch_user_id?: string
           twitch_video_id?: string
           type?: Database['public']['Enums']['twitch_video_type'] | null
           video_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: 'twitch_videos_twitch_user_id_fkey'
+            columns: ['twitch_user_id']
+            isOneToOne: false
+            referencedRelation: 'twitch_users'
+            referencedColumns: ['id']
+          },
           {
             foreignKeyName: 'twitch_videos_video_id_fkey'
             columns: ['video_id']
@@ -318,16 +328,19 @@ export type Database = {
         Row: {
           id: string
           video_id: string
+          youtube_channel_id: string | null
           youtube_video_id: string
         }
         Insert: {
           id?: string
           video_id: string
+          youtube_channel_id?: string | null
           youtube_video_id: string
         }
         Update: {
           id?: string
           video_id?: string
+          youtube_channel_id?: string | null
           youtube_video_id?: string
         }
         Relationships: [
@@ -336,6 +349,13 @@ export type Database = {
             columns: ['video_id']
             isOneToOne: true
             referencedRelation: 'videos'
+            referencedColumns: ['id']
+          },
+          {
+            foreignKeyName: 'youtube_videos_youtube_channel_id_fkey'
+            columns: ['youtube_channel_id']
+            isOneToOne: false
+            referencedRelation: 'youtube_channels'
             referencedColumns: ['id']
           },
         ]


### PR DESCRIPTION
This pull request updates the Supabase database type definitions to add new foreign key relationships and fields for Twitch and YouTube videos. The main changes enhance data modeling by associating videos with their respective user/channel entities.

**Twitch video relationship updates:**

* Added a new `twitch_user_id` field to the `twitch_videos` table and its corresponding types in `Row`, `Insert`, and `Update` definitions.
* Defined a new foreign key relationship from `twitch_videos.twitch_user_id` to `twitch_users.id`.

**YouTube video relationship updates:**

* Added a new `youtube_channel_id` field (nullable) to the `youtube_videos` table and its corresponding types in `Row`, `Insert`, and `Update` definitions.
* Defined a new foreign key relationship from `youtube_videos.youtube_channel_id` to `youtube_channels.id`.