### PR TITLE
fix(batch): update video association logic to use saved YouTube channel ID

### DIFF
--- a/apps/batch/lib/scraper/__tests__/scraper.test.ts
+++ b/apps/batch/lib/scraper/__tests__/scraper.test.ts
@@ -71,27 +71,27 @@ describe('DB class', () => {
     // Mock video data with IDs
     const values = [
       {
-        channel_id: '1',
+        channel_id: 'channel-uuid-1',
         created_at: '2023-01-01T00:00:00.000Z',
         deleted_at: null,
         duration: 'PT10M30S',
         id: 'test-uuid-1',
         platform: 'youtube' as const,
         published_at: '2023-01-01T12:00:00.000Z',
-        thumbnail_id: '1',
+        thumbnail_id: 'thumbnail-uuid-1',
         title: 'Test Video 1',
         updated_at: '2023-01-01T00:00:00.000Z',
         visible: true,
       },
       {
-        channel_id: '2',
+        channel_id: 'channel-uuid-2',
         created_at: '2023-01-02T00:00:00.000Z',
         deleted_at: null,
         duration: 'PT15M45S',
         id: 'test-uuid-2',
         platform: 'youtube' as const,
         published_at: '2023-01-02T12:00:00.000Z',
-        thumbnail_id: '2',
+        thumbnail_id: 'thumbnail-uuid-2',
         title: 'Test Video 2',
         updated_at: '2023-01-02T00:00:00.000Z',
         visible: true,
@@ -180,25 +180,25 @@ describe('DB class', () => {
 
     const values = [
       {
-        channel_id: '1',
+        channel_id: 'channel-uuid-1',
         created_at: '2023-01-01T00:00:00.000Z',
         deleted_at: null,
         duration: 'PT10M30S',
         platform: 'youtube' as const,
         published_at: '2023-01-01T12:00:00.000Z',
-        thumbnail_id: '1',
+        thumbnail_id: 'thumbnail-uuid-1',
         title: 'New Video 1',
         updated_at: '2023-01-01T00:00:00.000Z',
         visible: true,
       },
       {
-        channel_id: '1',
+        channel_id: 'channel-uuid-1',
         created_at: '2023-01-02T00:00:00.000Z',
         deleted_at: null,
         duration: 'PT8M15S',
         platform: 'youtube' as const,
         published_at: '2023-01-02T12:00:00.000Z',
-        thumbnail_id: '2',
+        thumbnail_id: 'thumbnail-uuid-2',
         title: 'New Video 2',
         updated_at: '2023-01-02T00:00:00.000Z',
         visible: true,
@@ -257,8 +257,8 @@ describe('Scraper class', () => {
         id: 'UCtest123',
       },
       savedYouTubeChannel: {
-        channel_id: '1',
-        id: '1',
+        channel_id: 'channel-uuid-1',
+        id: 'ytc-uuid-1',
         youtube_channel_id: 'UCtest123',
       },
       supabaseClient,
@@ -343,8 +343,8 @@ describe('Scraper class', () => {
         id: 'UCtest123',
       },
       savedYouTubeChannel: {
-        channel_id: '1',
-        id: '1',
+        channel_id: 'channel-uuid-1',
+        id: 'ytc-uuid-1',
         youtube_channel_id: 'UCtest123',
       },
       supabaseClient,
@@ -506,7 +506,11 @@ describe('YouTube video ID association bug fix', () => {
       }),
     )
 
-    await db.upsertVideos(values, youtubeVideoIds, 'UT_channel_456')
+    await db.upsertVideos(
+      values,
+      youtubeVideoIds,
+      '1cabb470-5d40-4afb-aee7-9b876ffa62e7',
+    )
 
     await new Promise((resolve) => setTimeout(resolve, 100))
 

--- a/apps/batch/lib/scraper/scraper.ts
+++ b/apps/batch/lib/scraper/scraper.ts
@@ -487,7 +487,7 @@ export default class Scraper implements AsyncDisposable {
     return this.#db.upsertVideos(
       values,
       youtubeVideoIds,
-      this.#savedYouTubeChannel.youtube_channel_id,
+      this.#savedYouTubeChannel.id,
     )
   }
 


### PR DESCRIPTION
This pull request updates the test data and internal method calls in the `scraper` module to consistently use UUIDs for channel and thumbnail identifiers, instead of simple numeric strings. This change improves the accuracy and reliability of tests and aligns identifier usage with production data models.

**Test data and identifier consistency:**

* Updated mock video data in `scraper.test.ts` to use UUIDs for `channel_id` and `thumbnail_id` fields, replacing previous numeric string values. This affects all test cases involving video objects. [[1]](diffhunk://#diff-613e4ba847b76f3aa4fa2209bb011d2f8709ae98e6c09733b5ff00c23d1a1816L74-R94) [[2]](diffhunk://#diff-613e4ba847b76f3aa4fa2209bb011d2f8709ae98e6c09733b5ff00c23d1a1816L183-R201)
* Changed mock channel objects in `scraper.test.ts` to use UUIDs for `channel_id` and `id` fields, ensuring test channels match the expected format. [[1]](diffhunk://#diff-613e4ba847b76f3aa4fa2209bb011d2f8709ae98e6c09733b5ff00c23d1a1816L260-R261) [[2]](diffhunk://#diff-613e4ba847b76f3aa4fa2209bb011d2f8709ae98e6c09733b5ff00c23d1a1816L346-R347)

**Method call updates:**

* Modified the `upsertVideos` method invocation in both tests and the `Scraper` class to pass the correct UUID for the channel, ensuring the association logic matches production expectations. [[1]](diffhunk://#diff-613e4ba847b76f3aa4fa2209bb011d2f8709ae98e6c09733b5ff00c23d1a1816L509-R513) [[2]](diffhunk://#diff-ac4d72fdad4987debceb2ff23de2a670cd52ef58252545450cd4f94a5639cb99L490-R490)