### PR TITLE
fix(admin): change summary widget grid layout to 2 columns

### DIFF
--- a/apps/admin/app/(dashboard)/_components/summary-widget.tsx
+++ b/apps/admin/app/(dashboard)/_components/summary-widget.tsx
@@ -23,7 +23,7 @@ export async function VideoSummaryWidget() {
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
       <h2 className="mb-4 font-semibold text-xl">動画サマリー</h2>
-      <div className="grid grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <Link
           className="rounded-lg bg-blue-50 p-4 transition-colors hover:bg-blue-100"
           href="/videos?deleted=false"


### PR DESCRIPTION
This pull request makes a small UI improvement to the `VideoSummaryWidget` component. The grid layout is now responsive, displaying two columns by default and four columns on large screens, which enhances usability on smaller devices.

- Updated the grid layout in `VideoSummaryWidget` to use two columns by default and four columns on large screens for better responsiveness (`apps/admin/app/(dashboard)/_components/summary-widget.tsx`).