### PR TITLE
fix(batch): filter saved videos by status 'ENDED'

### DIFF
--- a/apps/batch/app/videos/check/_lib/get-saved-videos.ts
+++ b/apps/batch/app/videos/check/_lib/get-saved-videos.ts
@@ -56,6 +56,7 @@ export async function* getSavedVideos({
         'id, duration, published_at, status, title, thumbnail:thumbnails (id), youtube_video:youtube_videos!inner (youtube_video_id)',
       )
       .is('deleted_at', null)
+      .eq('status', 'ENDED')
       .order('published_at', {
         ascending: false,
       })


### PR DESCRIPTION
This pull request introduces a small but important change to the `getSavedVideos` function. Now, only videos with a `status` of `'ENDED'` will be returned, in addition to those not marked as deleted. This ensures that only completed videos are included in the results.

* Restricts the query in `getSavedVideos` (`apps/batch/app/videos/check/_lib/get-saved-videos.ts`) to return only videos where `status` is `'ENDED'`.