### PR TITLE
fix(terraform): change `TURBO_PLATFORM_ENV_DISABLED` to true

### DIFF
--- a/terraform/project.tf
+++ b/terraform/project.tf
@@ -35,7 +35,7 @@ resource "vercel_project_environment_variable" "turbo_platform_env_disabled" {
   project_id = vercel_project.this.id
   target     = ["production", "preview"]
   team_id    = vercel_project.this.team_id
-  value      = "false"
+  value      = "true"
 }
 
 resource "vercel_project_environment_variable" "use_bytecode_caching" {
@@ -132,7 +132,7 @@ resource "vercel_project_environment_variable" "admin_turbo_platform_env_disable
   project_id = vercel_project.admin.id
   target     = ["production", "preview"]
   team_id    = vercel_project.admin.team_id
-  value      = "false"
+  value      = "true"
 }
 
 resource "vercel_project_environment_variable" "admin_use_bytecode_caching" {
@@ -226,7 +226,7 @@ resource "vercel_project_environment_variable" "batch_turbo_platform_env_disable
   project_id = vercel_project.batch.id
   target     = ["production", "preview"]
   team_id    = vercel_project.batch.team_id
-  value      = "false"
+  value      = "true"
 }
 
 resource "vercel_project_environment_variable" "batch_use_bytecode_caching" {


### PR DESCRIPTION
This pull request updates the configuration for several Vercel projects by changing the value of the `turbo_platform_env_disabled` environment variable from `"false"` to `"true"` across multiple resources. This effectively disables the Turbo platform environment for these projects in both production and preview environments.

Environment variable configuration updates:

* Set `value = "true"` for `turbo_platform_env_disabled` in the main project, disabling the Turbo platform environment.
* Set `value = "true"` for `admin_turbo_platform_env_disabled` in the admin project, disabling the Turbo platform environment.
* Set `value = "true"` for `batch_turbo_platform_env_disabled` in the batch project, disabling the Turbo platform environment.