### PR TITLE
feat(batch): update schedule for `/videos/check?mode=all` path

### DIFF
--- a/apps/batch/vercel.json
+++ b/apps/batch/vercel.json
@@ -23,7 +23,7 @@
     },
     {
       "path": "/videos/check?mode=all",
-      "schedule": "4 23 * * 2"
+      "schedule": "4 23 * * 2,4"
     },
     {
       "path": "/videos/update",


### PR DESCRIPTION
This pull request makes a minor update to the `vercel.json` configuration for scheduled functions. The schedule for the `/videos/check?mode=all` path has been adjusted to run on both Tuesdays and Thursdays instead of just Tuesdays.