### PR TITLE
fix(ci): Include '@shinju-date/ui' in CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
             language: "node"
           - name: "@shinju-date/temporal-fns"
             language: "node"
+          - name: "@shinju-date/ui"
+            language: "node"
           - name: "@shinju-date/youtube-api-client"
             language: "node"
           - name: "@shinju-date/youtube-scraper"


### PR DESCRIPTION
This pull request makes a small update to the CI workflow configuration by adding the `@shinju-date/ui` package to the list of Node.js projects that are processed during the workflow.

- Added `@shinju-date/ui` as a Node.js project in the CI workflow configuration (`.github/workflows/ci.yml`).