### PR TITLE
test: add comprehensive tests for stats/snapshot route functionality

### DIFF
--- a/apps/batch/app/stats/snapshot/__tests__/route.test.ts
+++ b/apps/batch/app/stats/snapshot/__tests__/route.test.ts
@@ -35,7 +35,7 @@ vi.mock('@/lib/ratelimit', () => ({
   statsSnapshot: mockRatelimit,
 }))
 
-vi.mock('../stats', () => ({
+vi.mock('../_lib/stats', () => ({
   getAnalyticsSummary: mockGetAnalyticsSummary,
   getSummaryStats: mockGetSummaryStats,
 }))
@@ -135,7 +135,7 @@ describe('stats/snapshot route', () => {
   describe('stats functions integration', () => {
     it('should call getSummaryStats and getAnalyticsSummary with correct parameters', async () => {
       // Import the route after mocks are set up
-      const { POST } = await import('../../route')
+      const { POST } = await import('../route')
 
       const request = new Request('http://localhost:3000/stats/snapshot', {
         method: 'POST',
@@ -163,7 +163,7 @@ describe('stats/snapshot route', () => {
   describe('Redis key usage', () => {
     it('should use previous day Redis keys for analytics', async () => {
       // Import the route after mocks are set up
-      const { POST } = await import('../../route')
+      const { POST } = await import('../route')
 
       const request = new Request('http://localhost:3000/stats/snapshot', {
         method: 'POST',


### PR DESCRIPTION
This pull request makes a minor update to the test file for the `stats/snapshot` route. The changes update import paths in the test cases to reflect a file move or restructuring.

- Updated import paths in `apps/batch/app/stats/snapshot/__tests__/route.test.ts` to use the correct relative path after the file was moved or renamed. [[1]](diffhunk://#diff-b0b713d120b9ac4ecb671d6aa0f296b8747488669173297aaecc11fd90b33ef5L138-R138) [[2]](diffhunk://#diff-b0b713d120b9ac4ecb671d6aa0f296b8747488669173297aaecc11fd90b33ef5L166-R166)