### PR TITLE
build(ci): Install Noto CJK fonts in workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: 
+      - name: Install CJK fonts
         run: |
           sudo apt-get update
-          sudo apt-get install fonts-noto-cjk
+          sudo apt-get install -y fonts-noto-cjk
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by installing the `fonts-noto-cjk` package. This ensures that the workflow environment has access to CJK (Chinese, Japanese, Korean) fonts, which may be necessary for proper rendering or testing of multilingual content.

- Workflow environment improvement:
  * [`.github/workflows/copilot-setup-steps.yml`](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dR22-R26): Added a step to install `fonts-noto-cjk` using `apt-get` to provide CJK font support in the workflow environment.