### PR TITLE
build(ci): Refactor Supabase CLI installation and usage

### DIFF
--- a/.github/workflows/supabase-db-push.yml
+++ b/.github/workflows/supabase-db-push.yml
@@ -33,13 +33,10 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Supabase CLI
-        run: npm install -g supabase
-
       - name: Run supabase db push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
         run: |
-          supabase link --project-ref "$SUPABASE_PROJECT_REF"
-          supabase db push
+          pnpm --filter @shinju-date/database exec supabase link --project-ref "$SUPABASE_PROJECT_REF"
+          pnpm --filter @shinju-date/database exec supabase db push


### PR DESCRIPTION
This pull request updates the Supabase database push workflow to use the local Supabase CLI installed in the `@shinju-date/database` package, rather than installing the CLI globally. This change ensures that the workflow uses the version of the CLI specified in the project dependencies and improves consistency across environments.

**Workflow and dependency management:**

* Removed the global installation of the Supabase CLI and updated the workflow to use `pnpm exec` within the `@shinju-date/database` package for running Supabase commands. This ensures the correct CLI version is used as defined by the project dependencies.