### PR TITLE
refactor: update Redis configuration and remove unnecessary options in Dev Container setup

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,48 @@
+# Docker Compose configuration for Dev Container
+# This runs alongside the main dev container and provides additional services
+
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/typescript-node:4-24-bookworm
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+    depends_on:
+      redis:
+        condition: service_healthy
+      serverless-redis-http:
+        condition: service_healthy
+
+  redis:
+    image: redis:8.4.0-bookworm
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  serverless-redis-http:
+    image: hiett/serverless-redis-http:0.0.10
+    ports:
+      - "8079:80"
+    environment:
+      SRH_MODE: env
+      SRH_TOKEN: local_development_token
+      SRH_CONNECTION_STRING: "redis://redis:6379"
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost/"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  redis-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,8 +12,8 @@
       "settings": {}
     }
   },
+  "dockerComposeFile": "compose.yml",
   "features": {
-    "ghcr.io/devcontainers-extra/features/supabase-cli:1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/python:1": {},
     "ghcr.io/devcontainers/features/terraform:1": {
@@ -22,13 +22,12 @@
       "version": "1.6.4"
     }
   },
-  "forwardPorts": [3000, 4000, 8000, 10000, 54321, 54323],
+  "forwardPorts": [3000, 4000, 8000, 8079, 10000, 54321, 54323],
   "hostRequirements": {
     "cpus": 4,
     "memory": "8gb",
     "storage": "32gb"
   },
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:4-24-bookworm",
   "name": "SHINJU DATE",
   "portsAttributes": {
     "3000": {
@@ -43,6 +42,14 @@
       "label": "Insights API",
       "onAutoForward": "silent"
     },
+    "8079": {
+      "label": "Redis HTTP API",
+      "onAutoForward": "silent"
+    },
+    "10000": {
+      "label": "Batch",
+      "onAutoForward": "silent"
+    },
     "54321": {
       "label": "Supabase API",
       "onAutoForward": "silent"
@@ -53,6 +60,8 @@
     }
   },
   "postCreateCommand": "./.devcontainer/post-create.sh",
-  "postStartCommand": "supabase start || true",
-  "waitFor": "postCreateCommand"
+  "postStartCommand": "pnpm exec supabase start || true",
+  "service": "app",
+  "waitFor": "postCreateCommand",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"
 }

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,6 +16,19 @@ jobs:
     permissions:
       contents: read
 
+    services:
+      redis:
+        image: redis:8.4.0-bookworm
+
+      serverless-redis-http:
+        image: hiett/serverless-redis-http:0.0.10
+        ports:
+          - 8079:80
+        env:
+          SRH_MODE: env
+          SRH_TOKEN: local_development_token
+          SRH_CONNECTION_STRING: redis://redis:6379
+
     steps:
       - uses: actions/checkout@v6
 
@@ -53,17 +66,15 @@ jobs:
       - name: Set Next.js Turbopack TLS environment variable
         run: echo 'NEXT_TURBOPACK_EXPERIMENTAL_USE_SYSTEM_TLS_CERTS=1' >> $GITHUB_ENV
 
+      - name: Start Supabase local development setup
+        run: |
+          pnpm exec supabase start
+
       - name: Set environment variables for Supabase and Upstash
         run: |
-          echo 'NEXT_PUBLIC_SUPABASE_URL=https://fake.supabase.test' >> $GITHUB_ENV
-          echo 'NEXT_PUBLIC_SUPABASE_ANON_KEY=fake-anon-key' >> $GITHUB_ENV
-          echo 'SUPABASE_SERVICE_ROLE_KEY=fake-service-role-key' >> $GITHUB_ENV
+          echo 'NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321' >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_SUPABASE_$(pnpm exec supabase status -o env | grep ANON_KEY)" >> $GITHUB_ENV
+          echo "SUPABASE_$(pnpm exec supabase status -o env | grep SERVICE_ROLE_KEY)" >> $GITHUB_ENV
 
-          echo 'UPSTASH_REDIS_REST_TOKEN=fake-upstash-token' >> $GITHUB_ENV
-          echo 'UPSTASH_REDIS_REST_URL=https://fake.upstash.test' >> $GITHUB_ENV
-
-      - name: Set MSW environment variable
-        run: echo 'ENABLE_MSW=true' >> $GITHUB_ENV
-
-      - name: Initialize MSW service workers for apps
-        run: pnpm --filter './apps/*' run msw:init
+          echo 'UPSTASH_REDIS_REST_TOKEN=local_development_token' >> $GITHUB_ENV
+          echo 'UPSTASH_REDIS_REST_URL=http://localhost:8079' >> $GITHUB_ENV

--- a/apps/admin/.env.local.sample
+++ b/apps/admin/.env.local.sample
@@ -4,6 +4,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="fake"
 NEXT_PUBLIC_SUPABASE_URL="https://fake.supabase.test"
 SUPABASE_SERVICE_ROLE_KEY="fake"
 
-# Upstash client (these are required, but can be fake values when `ENABLE_MSW=true`)
-UPSTASH_REDIS_REST_TOKEN="fake"
-UPSTASH_REDIS_REST_URL="https://fake.upstash.test"
+# Upstash client
+# Option 1: Use MSW for testing (no actual Redis needed)
+# UPSTASH_REDIS_REST_TOKEN="fake"
+# UPSTASH_REDIS_REST_URL="https://fake.upstash.test"
+#
+# Option 2: Use local Redis via serverless-redis-http (recommended for development)
+# Start with: pnpm redis:start
+UPSTASH_REDIS_REST_TOKEN="local_development_token"
+UPSTASH_REDIS_REST_URL="http://localhost:8079"

--- a/apps/batch/.env.local.sample
+++ b/apps/batch/.env.local.sample
@@ -3,6 +3,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="fake"
 NEXT_PUBLIC_SUPABASE_URL="https://fake.supabase.test"
 SUPABASE_SERVICE_ROLE_KEY="fake"
 
-# Upstash client (these are required, but can be fake values when `ENABLE_MSW=true`)
-UPSTASH_REDIS_REST_TOKEN="fake"
-UPSTASH_REDIS_REST_URL="https://fake.upstash.test"
+# Upstash client
+# Option 1: Use MSW for testing (no actual Redis needed)
+# UPSTASH_REDIS_REST_TOKEN="fake"
+# UPSTASH_REDIS_REST_URL="https://fake.upstash.test"
+#
+# Option 2: Use local Redis via serverless-redis-http (recommended for development)
+# Start with: pnpm redis:start
+UPSTASH_REDIS_REST_TOKEN="local_development_token"
+UPSTASH_REDIS_REST_URL="http://localhost:8079"

--- a/apps/insights/.env.example
+++ b/apps/insights/.env.example
@@ -2,9 +2,15 @@
 NEXT_PUBLIC_SUPABASE_URL=""
 SUPABASE_SERVICE_ROLE_KEY=""
 
-# Upstash Redis
-UPSTASH_REDIS_URL=""
-UPSTASH_REDIS_TOKEN=""
+# Upstash Redis Configuration
+# Option 1: Use local Redis via serverless-redis-http (recommended for development)
+# Start with: pnpm redis:start from the project root
+UPSTASH_REDIS_URL="http://localhost:8079"
+UPSTASH_REDIS_TOKEN="local_development_token"
+#
+# Option 2: Use production Upstash Redis (for production/staging)
+# UPSTASH_REDIS_URL=""
+# UPSTASH_REDIS_TOKEN=""
 
 # Cron
 CRON_SECRET=""

--- a/apps/web/.env.local.sample
+++ b/apps/web/.env.local.sample
@@ -3,9 +3,15 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3000
 NEXT_PUBLIC_SUPABASE_ANON_KEY="fake"
 NEXT_PUBLIC_SUPABASE_URL="https://fake.supabase.test"
 
-# Upstash client (these are required, but can be fake values when `ENABLE_MSW=true`)
-UPSTASH_REDIS_REST_TOKEN="fake"
-UPSTASH_REDIS_REST_URL="https://fake.upstash.test"
+# Upstash client
+# Option 1: Use MSW for testing (no actual Redis needed)
+# UPSTASH_REDIS_REST_TOKEN="fake"
+# UPSTASH_REDIS_REST_URL="https://fake.upstash.test"
+#
+# Option 2: Use local Redis via serverless-redis-http (recommended for development)
+# Start with: pnpm redis:start
+UPSTASH_REDIS_REST_TOKEN="local_development_token"
+UPSTASH_REDIS_REST_URL="http://localhost:8079"
 
 # Resend API configuration for contact form
 RESEND_API_KEY=

--- a/docs/REDIS_KNOWN_ISSUES.md
+++ b/docs/REDIS_KNOWN_ISSUES.md
@@ -1,0 +1,69 @@
+# Known Issues with Local Redis Setup
+
+## DNS Resolution in Docker Containers (serverless-redis-http)
+
+### Issue
+
+The `serverless-redis-http` container cannot resolve the `redis` service hostname through Docker's embedded DNS resolver in certain environments (particularly in CI/CD environments like GitHub Actions, Codespaces, or some Dev Container configurations).
+
+### Symptoms
+
+- `pnpm redis:start` successfully starts both containers
+- Both containers appear healthy in `docker ps`
+- TCP connectivity works when using IP addresses directly
+- HTTP requests to `http://localhost:8079` return 500 errors with message: "SRH: Unable to connect to the Redis server"
+- Logs show timeout errors: `** (EXIT) time out` when trying to connect to Redis
+
+### Root Cause
+
+The Elixir/OTP runtime used by serverless-redis-http appears to have issues resolving Docker service names through Docker's embedded DNS in certain network configurations. While `getent hosts redis` from within the container times out or fails, direct IP connectivity works fine (`nc -zv <IP> 6379` succeeds).
+
+### Workarounds
+
+1. **Use MSW (Recommended for CI/CD)**
+   - MSW provides a fully functional Redis mock without Docker
+   - Already implemented in `packages/msw-handlers/src/handlers/upstash.ts`
+   - Works in all environments (local, CI, Codespaces)
+   - Configured via `UPSTASH_REDIS_REST_URL=https://fake.upstash.test`
+
+2. **Use Local Docker (Recommended for Local Development)**
+   - Works on most local development machines (macOS, Windows, Linux)
+   - May fail in certain containerized environments (GitHub Actions, etc.)
+   - Test with `pnpm redis:start` and verify with `curl -X POST http://localhost:8079 -H "Authorization: Bearer local_development_token" -H "Content-Type: application/json" -d '["PING"]'`
+
+3. **Use Production Upstash (For Integration Testing)**
+   - Create a separate Upstash Redis instance for testing
+   - Configure with actual credentials
+
+### Environment-Specific Behavior
+
+| Environment | Docker Compose | MSW | Production Upstash |
+|-------------|---------------|-----|-------------------|
+| Local Machine (macOS/Windows/Linux) | ✅ Usually works | ✅ Always works | ✅ Always works |
+| GitHub Codespaces | ⚠️ May not work | ✅ Always works | ✅ Always works |
+| Dev Containers | ⚠️ May not work | ✅ Always works | ✅ Always works |
+| GitHub Actions CI | ❌ Known to fail | ✅ Always works | ✅ Always works |
+| Local Docker Desktop | ✅ Usually works | ✅ Always works | ✅ Always works |
+
+### Recommended Approach by Use Case
+
+1. **Unit Tests**: Use MSW
+2. **CI/CD**: Use MSW
+3. **Coding Agent Environments**: Use MSW  
+4. **Local Feature Development**: Try Docker Compose first, fallback to MSW if it doesn't work
+5. **Integration Testing**: Use production Upstash test instance
+
+### Future Improvements
+
+Potential solutions to explore:
+1. Use a different Redis HTTP proxy that doesn't have DNS resolution issues
+2. Configure custom DNS resolvers in serverless-redis-http
+3. Use host networking mode (though this has security implications)
+4. Build a simple Node.js-based Redis HTTP proxy as an alternative
+5. Use Redis Stack with built-in HTTP interface
+
+### References
+
+- [serverless-redis-http GitHub](https://github.com/hiett/serverless-redis-http)
+- [Docker Embedded DNS Documentation](https://docs.docker.com/config/containers/container-networking/#dns-services)
+- [Elixir inet Configuration](https://www.erlang.org/doc/apps/ert/inet_cfg.html)

--- a/docs/redis-local-development.md
+++ b/docs/redis-local-development.md
@@ -1,0 +1,390 @@
+# Redisローカル開発環境ガイド
+
+このドキュメントでは、SHINJU DATEプロジェクトにおけるRedisローカル開発環境の詳細な設定と使用方法について説明します。
+
+## 目次
+
+1. [概要](#概要)
+2. [アーキテクチャ](#アーキテクチャ)
+3. [初期セットアップ](#初期セットアップ)
+4. [使用方法](#使用方法)
+5. [トラブルシューティング](#トラブルシューティング)
+6. [MSW vs ローカルRedis](#msw-vs-ローカルredis)
+
+## 概要
+
+このプロジェクトでは、[serverless-redis-http](https://github.com/hiett/serverless-redis-http)を使用してローカル開発環境を構築しています。Dev Container（GitHub CodespacesやVS Code Dev Containers）を使用する場合、Redis 8とserverless-redis-httpが自動的に起動します。
+
+以下のメリットが得られます：
+
+- **Upstash互換性**: 本番環境（Upstash Redis）と同じREST APIを使用
+- **実際のRedis機能**: MSWモックではなく、本物のRedisの動作を検証
+- **データ永続化**: 開発中のデータがDockerボリュームに保存される
+- **オフライン開発**: インターネット接続なしでも開発可能
+- **コスト削減**: 本番Redisのクォータを消費しない
+- **自動起動**: Dev Containerを使用する場合、手動設定不要
+
+**推奨される使用法**:
+- **Dev Container（Codespaces/VS Code）**: 自動起動、設定不要
+- **ローカル開発マシン（Dev Containerなし）**: 手動でDocker Composeを起動
+- **CI/CD環境**: GitHub Actions用の設定済み（copilot-setup-steps.yml）
+- **動作しない場合**: MSWにフォールバック（設定済み）
+
+## アーキテクチャ
+
+ローカル環境では、以下のコンポーネントがDockerコンテナとして起動します：
+
+```
+┌──────────────────────────────────────────┐
+│  Your Application                        │
+│  (@upstash/redis client)                 │
+└────────────┬─────────────────────────────┘
+             │ HTTP REST API
+             │ (http://localhost:8079)
+             ▼
+┌──────────────────────────────────────────┐
+│  serverless-redis-http                   │
+│  (Upstash REST API compatible proxy)     │
+│  Port: 8079                              │
+└────────────┬─────────────────────────────┘
+             │ Redis Protocol
+             │ (redis://redis:6379)
+             ▼
+┌──────────────────────────────────────────┐
+│  Redis                                   │
+│  (Standard Redis server)                 │
+│  Port: 6379                              │
+└──────────────────────────────────────────┘
+```
+
+### コンポーネント
+
+- **Redis** (port 6379): 標準のRedisサーバー（Redis 8 Bookworm版）
+  - データはDockerボリュームに永続化
+  - AOF（Append Only File）モードで起動し、データ永続性を確保
+  - 最新の安定版（Redis 8.4.0）を使用
+  
+- **serverless-redis-http** (port 8079): HTTPプロキシサーバー（バージョン 0.0.10）
+  - Upstash REST APIと完全互換
+  - RedisプロトコルをHTTP REST APIに変換
+  - `@upstash/redis`クライアントとシームレスに連携
+  - バージョン固定により安定性を確保
+
+## 初期セットアップ
+
+### 前提条件
+
+**Dev Containerを使用する場合（推奨）:**
+- GitHub Codespaces、またはVS Code + Dev Containers拡張機能
+- 自動的にセットアップされるため、追加の設定は不要
+
+**Dev Containerを使用しない場合:**
+- **Docker**: ローカルマシンにDockerがインストールされ、起動していること
+- **Docker Compose**: Docker Composeが利用可能であること（最近のDockerに含まれています）
+
+### 1. Dev Containerでの自動セットアップ（推奨）
+
+Dev Container（GitHub CodespacesまたはVS Code Dev Containers）を使用する場合：
+
+1. Codespacesを開く、またはVS CodeでDev Containerを起動
+2. Redis サービスが自動的に起動します
+3. 追加の設定は不要です
+
+Redisサービスは`.devcontainer/compose.yml`で定義されており、コンテナ起動時に自動的に開始されます。
+
+### 2. 手動セットアップ（Dev Containerを使用しない場合）
+
+Dev Containerを使用せず、ローカルマシンで直接開発する場合：
+
+```bash
+cd .devcontainer
+docker compose up -d
+```
+
+このコマンドは：
+1. Redis 8とserverless-redis-httpを起動
+2. ヘルスチェックでサービスの準備完了を待機
+3. バックグラウンドで実行
+
+停止する場合：
+
+```bash
+cd .devcontainer
+docker compose down
+```
+
+### 3. 環境変数の設定
+
+#### オプション1: `.env.local`ファイルを編集（推奨）
+
+`apps/web/.env.local`、`apps/admin/.env.local`、`apps/batch/.env.local`ファイルで：
+
+```bash
+# ローカルRedisを使用
+UPSTASH_REDIS_REST_URL="http://localhost:8079"
+UPSTASH_REDIS_REST_TOKEN="local_development_token"
+```
+
+#### オプション2: シェルの環境変数として設定
+
+```bash
+export UPSTASH_REDIS_REST_URL=http://localhost:8079
+export UPSTASH_REDIS_REST_TOKEN=local_development_token
+```
+
+### 4. Python環境（`apps/insights`）の設定
+
+`apps/insights/.env`ファイルで：
+
+```bash
+UPSTASH_REDIS_URL="http://localhost:8079"
+UPSTASH_REDIS_TOKEN="local_development_token"
+```
+
+## 使用方法
+
+### Dev Containerでの使用
+
+Dev Containerを使用している場合、Redisサービスは自動的に起動しており、すぐに使用できます。
+
+### ステータス確認
+
+Redisサービスの稼働状況を確認：
+
+```bash
+# Dev Containerの場合
+docker ps | grep shinju-date-redis
+
+# または、コンテナのヘルスチェック確認
+docker inspect shinju-date-redis --format='{{.State.Health.Status}}'
+docker inspect shinju-date-redis-http --format='{{.State.Health.Status}}'
+```
+
+期待される出力：`healthy`
+
+### アプリケーションでの使用
+
+#### Node.js/TypeScript
+
+`@upstash/redis`クライアントが環境変数から自動的に設定を読み込みます：
+
+```typescript
+import { Redis } from '@upstash/redis'
+
+// Redis.fromEnv() は環境変数から設定を読み込む
+const redis = Redis.fromEnv()
+
+// 通常通り使用
+await redis.set('key', 'value')
+const value = await redis.get('key')
+```
+
+#### Python (apps/insights)
+
+Pythonアプリでも同様に環境変数から設定を読み込みます。
+
+### Redisサービスの停止と再起動
+
+**Dev Containerを使用している場合:**
+
+サービスはコンテナのライフサイクルと連動しています。コンテナを再起動すると、Redisサービスも自動的に再起動されます。
+
+**手動で起動した場合:**
+
+```bash
+# 停止
+cd .devcontainer
+docker compose down
+
+# 再起動
+docker compose up -d
+```
+
+### データのクリア
+
+開発データをクリアしたい場合は、Dockerボリュームを削除します：
+
+```bash
+# Redisサービスを停止
+cd .devcontainer
+docker compose down
+
+# ボリュームも含めて削除
+docker compose down -v
+
+# 再起動
+docker compose up -d
+```
+
+## トラブルシューティング
+
+### Redisが起動しない
+
+#### 原因1: Dockerが起動していない
+
+```bash
+# Dockerの状態を確認
+docker info
+```
+
+Dockerが起動していない場合は、Dockerを起動してから再試行してください。
+
+#### 原因2: ポートが既に使用されている
+
+```bash
+# ポート8079または6379が使用中か確認
+lsof -i :8079
+lsof -i :6379
+
+# または (Linuxの場合)
+ss -tuln | grep -E ':(8079|6379)'
+```
+
+既に使用されている場合は、そのプロセスを停止するか、`docker-compose.redis.yml`でポート番号を変更してください。
+
+### 接続エラー
+
+#### エラー: "Connection refused" または "ECONNREFUSED"
+
+```bash
+# サービスの状態を確認
+pnpm redis:status
+
+# ログを確認
+docker logs shinju-date-redis-http
+docker logs shinju-date-redis
+```
+
+サービスが`healthy`状態でない場合は、ログを確認してエラーの原因を特定してください。
+
+#### エラー: "SRH: Unable to connect to the Redis server"
+
+**Dev Containerを使用している場合:**
+
+通常この問題は発生しません。`.devcontainer/compose.yml`のDocker Composeネットワーク設定により、サービス間の接続が自動的に解決されます。
+
+**手動で起動した場合で問題が発生する場合:**
+
+環境変数をMSWに切り替えます：
+
+```bash
+# .env.localファイルで
+UPSTASH_REDIS_REST_URL="https://fake.upstash.test"
+UPSTASH_REDIS_REST_TOKEN="fake"
+```
+
+MSWは全ての環境で動作する完全なRedisモックを提供します。
+
+#### エラー: "Invalid token"
+
+環境変数のトークンが正しく設定されているか確認してください：
+
+```bash
+# .env.localファイルを確認
+cat apps/web/.env.local | grep UPSTASH_REDIS_REST_TOKEN
+
+# トークンは "local_development_token" である必要があります
+```
+
+### パフォーマンスの問題
+
+#### メモリ不足
+
+Dockerに割り当てられたメモリを増やしてください。Docker Desktopの設定で、最低4GB（推奨8GB）のメモリを割り当ててください。
+
+#### ディスク容量不足
+
+```bash
+# Dockerのディスク使用量を確認
+docker system df
+
+# 不要なデータをクリーンアップ
+docker system prune -a
+```
+
+### コンテナが頻繁に再起動する
+
+```bash
+# ログを確認
+docker logs shinju-date-redis-http --tail 100
+docker logs shinju-date-redis --tail 100
+
+# コンテナの詳細情報を確認
+docker inspect shinju-date-redis-http
+docker inspect shinju-date-redis
+```
+
+## MSW vs ローカルRedis
+
+プロジェクトでは、Redis開発に2つのアプローチを提供しています：
+
+### MSW (Mock Service Worker)
+
+**利点:**
+- セットアップ不要（追加の依存関係なし）
+- 高速（実際のRedis接続なし）
+- テストに適している
+- CI環境で軽量
+
+**欠点:**
+- モックデータのみ（`packages/msw-handlers`で定義）
+- 一部のRedisコマンドは実装されていない
+- データ永続化なし
+
+**使用場面:**
+- ユニットテスト
+- E2Eテスト
+- CI/CD環境
+- 簡単な動作確認
+
+### ローカルRedis (serverless-redis-http)
+
+**利点:**
+- 実際のRedisの動作
+- 全てのRedisコマンドをサポート
+- データ永続化
+- 本番環境に近い動作
+
+**欠点:**
+- Dockerのセットアップが必要
+- 若干のメモリ使用
+- 起動/停止の手間
+
+**使用場面:**
+- 機能開発
+- データ永続化が必要な開発
+- Redisの高度な機能を使用する場合
+- 本番環境に近い動作確認
+
+### どちらを選ぶべきか？
+
+| シナリオ | 推奨 |
+|---------|------|
+| 新機能の開発 | ローカルRedis |
+| ユニットテスト | MSW |
+| E2Eテスト | MSW |
+| CI/CD | MSW |
+| データ永続化が必要 | ローカルRedis |
+| Redisの高度な機能 | ローカルRedis |
+| 簡単な動作確認 | MSW |
+
+**ヒント**: 両方を環境変数の切り替えで簡単に使い分けることができます。
+
+```bash
+# MSWを使用
+export UPSTASH_REDIS_REST_URL="https://fake.upstash.test"
+export UPSTASH_REDIS_REST_TOKEN="fake"
+
+# ローカルRedisを使用
+export UPSTASH_REDIS_REST_URL="http://localhost:8079"
+export UPSTASH_REDIS_REST_TOKEN="local_development_token"
+```
+
+## 参考資料
+
+- [serverless-redis-http GitHub](https://github.com/hiett/serverless-redis-http)
+- [Upstash Redis 公式ドキュメント](https://upstash.com/docs/redis)
+- [Upstash ローカル開発ガイド](https://upstash.com/docs/redis/sdks/ts/developing)
+- [Redis コマンドリファレンス](https://redis.io/commands/)
+- [Docker Compose ドキュメント](https://docs.docker.com/compose/)
+- [既知の問題とトラブルシューティング](./REDIS_KNOWN_ISSUES.md)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "SHINJU DATE is a web service for searching videos.",
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
+    "supabase": "2.63.1",
     "turbo": "2.6.1",
     "typescript": "5.9.3"
   },
@@ -20,6 +21,7 @@
     "build": "turbo build",
     "check": "biome check",
     "db:export": "./scripts/export-production-data.sh",
+    "db:schema": "supabase gen types typescript --local --schema public > packages/database/types/supabase.ts",
     "db:import": "./scripts/import-data.sh",
     "dev": "turbo dev",
     "test": "turbo test",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -6,7 +6,6 @@
     "@tsconfig/node20": "20.1.8",
     "@tsconfig/strictest": "2.0.8",
     "next": "16.0.6",
-    "supabase": "2.63.1",
     "tsup": "8.5.1",
     "typescript": "5.9.3"
   },
@@ -25,8 +24,7 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch",
-    "generate": "supabase gen types typescript --project-id $SUPABASE_PROJECT_ID --schema public > types/supabase.ts"
+    "dev": "tsup --watch"
   },
   "type": "module",
   "types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.3.8
         version: 2.3.8
+      supabase:
+        specifier: 2.63.1
+        version: 2.63.1
       turbo:
         specifier: 2.6.1
         version: 2.6.1
@@ -594,9 +597,6 @@ importers:
       next:
         specifier: 16.0.6
         version: 16.0.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      supabase:
-        specifier: 2.63.1
-        version: 2.63.1
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)


### PR DESCRIPTION
This pull request adds robust support for local Redis development and improves the developer experience across local, CI/CD, and Dev Container environments. It introduces a Docker Compose setup for Redis and a serverless-redis-http proxy, updates environment variable samples and documentation, and enhances workflow automation for consistent Redis access in all environments.

**Local Redis Setup and Dev Container Integration:**

- Added `.devcontainer/compose.yml` to define services for local Redis (`redis:8.4.0-bookworm`) and an Upstash-compatible HTTP proxy (`serverless-redis-http`), with health checks and port mappings for seamless integration in Dev Containers.
- Updated `.devcontainer/devcontainer.json` to use the new Docker Compose file, forward the Redis HTTP API port (8079), set the main service to `app`, and ensure the workspace folder is correctly mounted. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R15-L16) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L25-L31) [[3]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R45-R52) [[4]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L56-R66)

**CI/CD and Workflow Improvements:**

- Enhanced GitHub Actions workflow (`copilot-setup-steps.yml`) to spin up Redis and serverless-redis-http services during CI, and to set environment variables dynamically for Supabase and Upstash, enabling tests to use the local Redis HTTP proxy. [[1]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dR19-R31) [[2]](diffhunk://#diff-98dad98422cf59793a353f9b6bfe6a129977e92af3d5b4e38f98ae45bcb7560dL56-R80)

**Environment Variable and Sample File Updates:**

- Updated `.env.local.sample` and `.env.example` files across all apps (`admin`, `batch`, `web`, `insights`) to recommend using the local Redis HTTP proxy by default, with clear instructions for switching between MSW mock and real Redis setups. [[1]](diffhunk://#diff-e9f38fbc9cf3ca2d1d405520f9f776012349c661327a0049c3d618c81bd61179L7-R15) [[2]](diffhunk://#diff-5b34339bf562b1b885afc201a66915a12fc5cec98862776cb537f2cadb3791b1L6-R14) [[3]](diffhunk://#diff-e83bd46034d50e2f66860f0b9e20f1200de02edb6ba6388d3486f1b711366fdeL6-R14) [[4]](diffhunk://#diff-4d091d49b297b08f3dffaaff5c9b740f68f6975e488537760c273b243a03dc95L5-R13)

**Documentation Enhancements:**

- Added `docs/REDIS_KNOWN_ISSUES.md` to document known issues with Docker DNS resolution for serverless-redis-http, environment-specific behaviors, and recommended workarounds.
- Revised `docs/SETUP_GUIDE.md` to include detailed instructions for local Redis setup, Dev Container automation, manual Docker Compose usage, environment variable configuration, and fallback to MSW when necessary. [[1]](diffhunk://#diff-f689af0a65fd68b6851f704fcb1276013da5fc43bfe5a5972d772a502f23e07bL88-R140) [[2]](diffhunk://#diff-f689af0a65fd68b6851f704fcb1276013da5fc43bfe5a5972d772a502f23e07bL101-R151) [[3]](diffhunk://#diff-f689af0a65fd68b6851f704fcb1276013da5fc43bfe5a5972d772a502f23e07bL122-R172) [[4]](diffhunk://#diff-f689af0a65fd68b6851f704fcb1276013da5fc43bfe5a5972d772a502f23e07bL132-R182)