### PR TITLE
build(devcontainer): remove postStartCommand from devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,7 +60,6 @@
     }
   },
   "postCreateCommand": "./.devcontainer/post-create.sh",
-  "postStartCommand": "pnpm exec supabase start || true",
   "service": "app",
   "waitFor": "postCreateCommand",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}"


### PR DESCRIPTION
This pull request makes a minor change to the `.devcontainer/devcontainer.json` file by removing the `postStartCommand`, which previously started the Supabase service after the container was created.