### PR TITLE
feat(web): update video fetch functions for time range

### DIFF
--- a/apps/web/lib/fetchers.ts
+++ b/apps/web/lib/fetchers.ts
@@ -151,7 +151,7 @@ async function fetchRecentVideos(): Promise<Video[]> {
     .select(DEFAULT_SEARCH_SELECT)
     .eq('status', 'PUBLISHED')
     .neq('video_kind', 'short')
-    .gte('published_at', toDBString(fortyEightHoursAgo))
+    .gte('published_at', toDBString(threeDaysAgo))
     .lte('published_at', toDBString(now))
     .order('published_at', { ascending: false })
     .limit(10)


### PR DESCRIPTION
This pull request updates the time windows for fetching recent videos and shorts in the `fetchers.ts` file. The main change is extending the period for "recent videos" to three days and narrowing the period for "recent shorts" to one day, providing more accurate and relevant results for each category.

**Updates to video fetching timeframes:**

* Changed the "recent videos" window from 48 hours to 3 days in both documentation and logic, ensuring more videos are included in the recent list. [[1]](diffhunk://#diff-300a485c6ded82136851a8047e37e000dae5f77606c87167223fe7d113f2c5adL138-R138) [[2]](diffhunk://#diff-300a485c6ded82136851a8047e37e000dae5f77606c87167223fe7d113f2c5adL147-R147)
* Changed the "recent shorts" window from 48 hours to 1 day in both documentation and logic, focusing on the most current shorts. [[1]](diffhunk://#diff-300a485c6ded82136851a8047e37e000dae5f77606c87167223fe7d113f2c5adL169-R169) [[2]](diffhunk://#diff-300a485c6ded82136851a8047e37e000dae5f77606c87167223fe7d113f2c5adL178-R185)